### PR TITLE
fix: articleのnew/edit時のエラーメッセージを修正

### DIFF
--- a/app/views/shared/_article_error_messages.html.erb
+++ b/app/views/shared/_article_error_messages.html.erb
@@ -1,13 +1,12 @@
 <% if @article.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
+      <% @article.errors.delete(:slug) %>
       The form contains <%= pluralize(@article.errors.count, "error") %>.
     </div>
     <ul class="error-messages">
     <% @article.errors.full_messages.each do |msg| %>
-      <% unless msg == "Slug is invalid" %>
-        <li><%= msg %></li>
-      <% end %>
+      <li><%= msg %></li>
     <% end %>
     </ul>
   </div>

--- a/test/integration/articles_edit_test.rb
+++ b/test/integration/articles_edit_test.rb
@@ -21,5 +21,10 @@ class ArticlesEditTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
     get edit_article_path(@article.slug)
     assert_template 'articles/edit'
+    patch article_path(@article.slug), params: { article: { title: "title desuyo", 
+                                                            description: "description desuyo", 
+                                                            content: "contet desuyo" } }
+    assert_response :see_other
+    assert_redirected_to article_url(@article.slug)
   end
 end

--- a/test/integration/articles_error_test.rb
+++ b/test/integration/articles_error_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ArticlesErrorTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test "titleがエラーでslugもエラーのとき" do
+    log_in_as(@user)
+    post articles_path, params: { article: { title: "?", description: "description", content: "content" } }
+    assert_template 'articles/new'
+    @article = assigns(:article)
+    error_pul = "error".pluralize(@article.errors.count)
+    assert_select 'div.alert-danger', text: "The form contains #{@article.errors.count} #{error_pul}."
+    assert_select 'li', text: 'Title is invalid'
+    assert_select 'li', text: 'Slug is invalid', count: 0 # slugのエラーメッセージは表示されない
+  end
+
+  test "titleがエラーでslugはエラーでないとき" do
+    log_in_as(@user)
+    @article = @user.articles.create(title: 'title dayo', slug: 'title-dayo', description: 'description', content: 'content')
+    patch article_path(@article.slug), params: { article: { title: "?", description: "description", content: "content" } }
+    @article = assigns(:article)
+    error_pul = "error".pluralize(@article.errors.count)
+    assert_select 'div.alert-danger', text: "The form contains #{@article.errors.count} #{error_pul}."
+    assert_select 'li', text: 'Title is invalid'
+    assert_select 'li', text: 'Slug is invalid', count: 0 # slugのエラーメッセージは表示されない
+  end
+end


### PR DESCRIPTION
## 実施タスク
記事をnew/editするときのエラーメッセージの修正

## 実施内容
- slugのエラーを表示しない仕組みのバグ取り
- エラー時のメッセージのテストを作成

## その他/備考
- validな情報でのeditのテストの修正もこのプルリクに入ってしまった